### PR TITLE
Fix installation details URL format in constants.py

### DIFF
--- a/src/redbacktechpy/constants.py
+++ b/src/redbacktechpy/constants.py
@@ -76,11 +76,11 @@ class Endpoint(StrEnum):
     PORTAL_INVERTER_SET = "productcontrol/Index"
     PORTAL_LOGOFF = "Account/LogOff/"
     PORTAL_DETAILS = "productcontrol/Details?serialNumber="
-    PORTAL_INSTALLATION_DETAILS = "/installationdetails/Configure?serialNumber="
+    PORTAL_INSTALLATION_DETAILS = "installationdetails/Configure?serialNumber="
     API_SCHEDULE_BY_SERIALNUMBER = "Api/v2/Schedule/By/SerialNumber/"
     API_SCHEDULE_CREATE_BY_SERIALNUMBER = "Api/v2/Schedule/Create/By/SerialNumber/"
     API_SCHEDULE_DELETE_BY_SERIALNUMBER_SCHEDULEID = (
-        "/Api/v2/Schedule/By/SerialNumber/"  # {serialNumber}/{scheduleId}
+        "Api/v2/Schedule/By/SerialNumber/"  # {serialNumber}/{scheduleId}
     )
 
 


### PR DESCRIPTION
## Summary by Sourcery

Correct endpoint path constants for installation details and schedule-by-serial APIs to ensure consistent URL formatting.

Bug Fixes:
- Fix the installation details endpoint constant to remove an unnecessary leading slash that broke URL construction.
- Fix the schedule-by-serial-number endpoint constant to remove an unnecessary leading slash for proper API URL assembly.